### PR TITLE
Feat/add resume engine param

### DIFF
--- a/src/main/java/org/icgc/argo/workflow_management/controller/RunsApi.java
+++ b/src/main/java/org/icgc/argo/workflow_management/controller/RunsApi.java
@@ -22,6 +22,7 @@ public interface RunsApi {
               + "The workflow_attachment is part of the GA4GH WES API Standard however we currently not supporting it as of this release.\n\n"
               + "The workflow_url is the workflow GitHub repository URL (ex. icgc-argo/nextflow-dna-seq-alignment) that is accessible by the WES endpoint.\n\n"
               + "The workflow_params JSON object specifies the input parameters for a workflow. The exact format of the JSON object depends on the conventions of the workflow.\n\n"
+              + "The workflow_engine_parameters JSON object specifies additional run-time arguments to the workflow engine (ie. specific workflow version, resuming a workflow, etc.)"
               + "The workflow_type is the type of workflow language, currently this WES API supports \"nextflow\" only.\n\n"
               + "The workflow_type_version is the version of the workflow language to run the workflow against and must be one supported by this WES instance.\n",
       response = RunsResponse.class,

--- a/src/main/java/org/icgc/argo/workflow_management/controller/model/WorkflowEngineParameters.java
+++ b/src/main/java/org/icgc/argo/workflow_management/controller/model/WorkflowEngineParameters.java
@@ -15,4 +15,5 @@ import lombok.NoArgsConstructor;
 public class WorkflowEngineParameters {
   private String defaultContainer;
   private String workflowVersion;
+  private String resume;
 }

--- a/src/main/java/org/icgc/argo/workflow_management/service/NextflowService.java
+++ b/src/main/java/org/icgc/argo/workflow_management/service/NextflowService.java
@@ -122,9 +122,13 @@ public class NextflowService implements WorkflowExecutionService {
     // Dynamic engine properties/config
     val workflowEngineOptions = params.getWorkflowEngineParameters();
 
-    // Use revision if provided in workflow_engine_options
     if (nonNull(workflowEngineOptions)) {
 
+      // Resume workflow by name/id
+      if (nonNull(workflowEngineOptions.getResume())) {
+        cmdParams.put("resume", workflowEngineOptions.getResume());
+      }
+      // Use revision if provided in workflow_engine_options
       if (nonNull(workflowEngineOptions.getWorkflowVersion())) {
         cmdParams.put("revision", workflowEngineOptions.getWorkflowVersion());
       }

--- a/src/main/java/org/icgc/argo/workflow_management/service/NextflowService.java
+++ b/src/main/java/org/icgc/argo/workflow_management/service/NextflowService.java
@@ -95,7 +95,11 @@ public class NextflowService implements WorkflowExecutionService {
     val cmdParams = new HashMap<String, Object>();
 
     // run name (used for paramsFile as well)
-    val runName = UUID.randomUUID().toString();
+    // You may be asking yourself, why is he replacing the "-" in the UUID, this is a valid question,
+    // well unfortunately when trying to resume a job, Nextflow searches for the UUID format ANYWHERE in the
+    // resume string, resulting in the incorrect assumption that we are passing an runId when in fact we are passing
+    // a runName ... thanks Nextflow ... this workaround solves that problem
+    val runName = String.format("wes-%s", UUID.randomUUID().toString().replace("-", ""));
 
     // assign UUID as the run name
     cmdParams.put("runName", runName);


### PR DESCRIPTION
* changing the name format to not look like a UUID (this is needed for resume to work)
* adding `resume` as a parameter to `workflow_engine_parameters`