### PR TITLE
Feat/k8s secrets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,15 @@
             <artifactId>spring-security-oauth2-jose</artifactId>
             <version>5.3.3.RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+            <version>2.0.2.RELEASE</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/org/icgc/argo/workflow_management/config/secret/ApiKeyConfig.java
+++ b/src/main/java/org/icgc/argo/workflow_management/config/secret/ApiKeyConfig.java
@@ -16,36 +16,27 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.icgc.argo.workflow_management.config.security;
+package org.icgc.argo.workflow_management.config.secret;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
+import org.icgc.argo.workflow_management.secret.impl.ApiKeyProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
-@Data
+@Profile("apiKey")
 @Configuration
-@ConfigurationProperties(prefix = "auth")
-public class AuthProperties {
+public class ApiKeyConfig {
 
-  String jwtPublicKeyUrl;
+  @Value("${secret.enabled}")
+  private Boolean enabled;
 
-  String jwtPublicKeyStr;
+  @Value("${secret.apiKey}")
+  private String apiKey;
 
-  GraphqlScopes graphqlScopes;
-
-  @Value
-  @ConstructorBinding
-  public static class GraphqlScopes {
-    ImmutableList<String> queryOnly;
-    ImmutableList<String> queryAndMutation;
-
-    public GraphqlScopes(List<String> queryOnly, List<String> queryAndMutation) {
-      this.queryOnly = ImmutableList.copyOf(queryOnly);
-      this.queryAndMutation = ImmutableList.copyOf(queryAndMutation);
-    }
+  @Bean
+  public SecretProvider getApiKeyProvider() {
+    return new ApiKeyProvider(enabled, apiKey);
   }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/config/secret/NoSecretProviderConfig.java
+++ b/src/main/java/org/icgc/argo/workflow_management/config/secret/NoSecretProviderConfig.java
@@ -16,36 +16,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.icgc.argo.workflow_management.config.security;
+package org.icgc.argo.workflow_management.config.secret;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
+import org.icgc.argo.workflow_management.secret.impl.NoSecretProvider;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Data
 @Configuration
-@ConfigurationProperties(prefix = "auth")
-public class AuthProperties {
+public class NoSecretProviderConfig {
 
-  String jwtPublicKeyUrl;
-
-  String jwtPublicKeyStr;
-
-  GraphqlScopes graphqlScopes;
-
-  @Value
-  @ConstructorBinding
-  public static class GraphqlScopes {
-    ImmutableList<String> queryOnly;
-    ImmutableList<String> queryAndMutation;
-
-    public GraphqlScopes(List<String> queryOnly, List<String> queryAndMutation) {
-      this.queryOnly = ImmutableList.copyOf(queryOnly);
-      this.queryAndMutation = ImmutableList.copyOf(queryAndMutation);
-    }
+  @Bean
+  public SecretProvider noSecretProvider() {
+    return new NoSecretProvider();
   }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/config/secret/OAuth2TokenConfig.java
+++ b/src/main/java/org/icgc/argo/workflow_management/config/secret/OAuth2TokenConfig.java
@@ -16,36 +16,33 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.icgc.argo.workflow_management.config.security;
+package org.icgc.argo.workflow_management.config.secret;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
+import org.icgc.argo.workflow_management.secret.impl.OAuth2BearerTokenProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
-@Data
+@Profile("oauth2Token")
 @Configuration
-@ConfigurationProperties(prefix = "auth")
-public class AuthProperties {
+public class OAuth2TokenConfig {
 
-  String jwtPublicKeyUrl;
+  @Value("${secret.enabled}")
+  private Boolean enabled;
 
-  String jwtPublicKeyStr;
+  @Value("${secret.clientId}")
+  private String clientId;
 
-  GraphqlScopes graphqlScopes;
+  @Value("${secret.clientSecret}")
+  private String clientSecret;
 
-  @Value
-  @ConstructorBinding
-  public static class GraphqlScopes {
-    ImmutableList<String> queryOnly;
-    ImmutableList<String> queryAndMutation;
+  @Value("${secret.tokenUri}")
+  private String tokenUri;
 
-    public GraphqlScopes(List<String> queryOnly, List<String> queryAndMutation) {
-      this.queryOnly = ImmutableList.copyOf(queryOnly);
-      this.queryAndMutation = ImmutableList.copyOf(queryAndMutation);
-    }
+  @Bean
+  public SecretProvider getOAuth2BearerTokenProvider() {
+    return new OAuth2BearerTokenProvider(enabled, clientId, clientSecret, tokenUri);
   }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/config/security/AuthDisabledConfig.java
+++ b/src/main/java/org/icgc/argo/workflow_management/config/security/AuthDisabledConfig.java
@@ -25,17 +25,13 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
-
 @EnableWebFluxSecurity
 @Slf4j
 @Profile("!secure")
 public class AuthDisabledConfig {
-    @Bean
-    public SecurityWebFilterChain securityFilterChain(ServerHttpSecurity http) {
-        http
-            .csrf().disable()
-            .authorizeExchange()
-            .pathMatchers("/**").permitAll();
-        return http.build();
-    }
+  @Bean
+  public SecurityWebFilterChain securityFilterChain(ServerHttpSecurity http) {
+    http.csrf().disable().authorizeExchange().pathMatchers("/**").permitAll();
+    return http.build();
+  }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/config/security/AuthEnabledConfig.java
+++ b/src/main/java/org/icgc/argo/workflow_management/config/security/AuthEnabledConfig.java
@@ -18,7 +18,17 @@
 
 package org.icgc.argo.workflow_management.config.security;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import com.google.common.collect.ImmutableList;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.*;
+import java.util.function.Function;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -42,123 +52,114 @@ import org.springframework.security.oauth2.server.resource.authentication.Reacti
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import reactor.core.publisher.Mono;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.security.KeyFactory;
-import java.security.interfaces.RSAPublicKey;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.*;
-import java.util.function.Function;
-
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toUnmodifiableList;
-
-
 @EnableWebFluxSecurity
 @Slf4j
 @Profile("secure")
 @EnableReactiveMethodSecurity
 public class AuthEnabledConfig {
 
-    private final AuthProperties authProperties;
+  private final AuthProperties authProperties;
 
-    private final ResourceLoader resourceLoader;
+  private final ResourceLoader resourceLoader;
 
-    @Autowired
-    public AuthEnabledConfig(AuthProperties authProperties, ResourceLoader resourceLoader) {
-        this.authProperties = authProperties;
-        this.resourceLoader = resourceLoader;
-    }
+  @Autowired
+  public AuthEnabledConfig(AuthProperties authProperties, ResourceLoader resourceLoader) {
+    this.authProperties = authProperties;
+    this.resourceLoader = resourceLoader;
+  }
 
-    @Bean
-    public SecurityWebFilterChain securityFilterChain(
-            ServerHttpSecurity http) {
-        http
-                .csrf().disable()
-                .authorizeExchange()
-                .pathMatchers("/actuator/**").permitAll()
-                .pathMatchers("/runs/**").permitAll()
-            .and()
-                .authorizeExchange()
-                .anyExchange().authenticated()
-            .and()
-                .oauth2ResourceServer().jwt()
-                .jwtDecoder(jwtDecoder())
-                .jwtAuthenticationConverter(grantedAuthoritiesExtractor());
-        return http.build();
-    }
+  @Bean
+  public SecurityWebFilterChain securityFilterChain(ServerHttpSecurity http) {
+    http.csrf()
+        .disable()
+        .authorizeExchange()
+        .pathMatchers("/actuator/**")
+        .permitAll()
+        .pathMatchers("/runs/**")
+        .permitAll()
+        .and()
+        .authorizeExchange()
+        .anyExchange()
+        .authenticated()
+        .and()
+        .oauth2ResourceServer()
+        .jwt()
+        .jwtDecoder(jwtDecoder())
+        .jwtAuthenticationConverter(grantedAuthoritiesExtractor());
+    return http.build();
+  }
 
-    private Converter<Jwt, Mono<AbstractAuthenticationToken>> grantedAuthoritiesExtractor() {
-        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
-        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(this.jwtToGrantedAuthoritiesConverter);
-        return new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
-    }
+  private Converter<Jwt, Mono<AbstractAuthenticationToken>> grantedAuthoritiesExtractor() {
+    JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+    jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(
+        this.jwtToGrantedAuthoritiesConverter);
+    return new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
+  }
 
-    private final Converter<Jwt, Collection<GrantedAuthority>> jwtToGrantedAuthoritiesConverter = (jwt) -> {
+  private final Converter<Jwt, Collection<GrantedAuthority>> jwtToGrantedAuthoritiesConverter =
+      (jwt) -> {
         val scopesBuilder = ImmutableList.<String>builder();
 
         try {
-            val context = (Map<String, Object>) jwt.getClaims().get("context");
-            scopesBuilder.addAll((Collection<String>) context.get("scope"));
+          val context = (Map<String, Object>) jwt.getClaims().get("context");
+          scopesBuilder.addAll((Collection<String>) context.get("scope"));
         } catch (Exception e) {
-            log.error("Unable to extract scopes from JWT");
+          log.error("Unable to extract scopes from JWT");
         }
 
-        return scopesBuilder.build().stream()
-                       .map(SimpleGrantedAuthority::new)
-                       .collect(toList());
+        return scopesBuilder.build().stream().map(SimpleGrantedAuthority::new).collect(toList());
+      };
+
+  @SneakyThrows
+  private ReactiveJwtDecoder jwtDecoder() {
+    String publicKeyStr;
+
+    val publicKeyUrl = authProperties.getJwtPublicKeyUrl();
+    if (publicKeyUrl != null && !publicKeyUrl.isEmpty()) {
+      publicKeyStr = fetchJWTPublicKey(publicKeyUrl);
+    } else {
+      publicKeyStr = authProperties.getJwtPublicKeyStr();
+    }
+
+    val publicKeyContent =
+        publicKeyStr
+            .replaceAll("\\n", "")
+            .replace("-----BEGIN PUBLIC KEY-----", "")
+            .replace("-----END PUBLIC KEY-----", "");
+
+    KeyFactory kf = KeyFactory.getInstance("RSA");
+    X509EncodedKeySpec keySpecX509 =
+        new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyContent));
+    RSAPublicKey publicKey = (RSAPublicKey) kf.generatePublic(keySpecX509);
+
+    return NimbusReactiveJwtDecoder.withPublicKey(publicKey).build();
+  }
+
+  @SneakyThrows
+  private String fetchJWTPublicKey(String publicKeyUrl) {
+    log.info("Fetching EGO public key");
+    val publicKeyResource = resourceLoader.getResource(publicKeyUrl);
+
+    val stringBuilder = new StringBuilder();
+    val reader = new BufferedReader(new InputStreamReader(publicKeyResource.getInputStream()));
+
+    reader.lines().forEach(stringBuilder::append);
+    return stringBuilder.toString();
+  }
+
+  @Bean
+  public Function<Authentication, Boolean> queryAndMutationScopeChecker() {
+    val expectedScopes = authProperties.getGraphqlScopes().getQueryAndMutation();
+    return authentication -> {
+      val scopes =
+          authentication.getAuthorities().stream()
+              .map(Objects::toString)
+              .collect(toUnmodifiableList());
+
+      val foundScopes =
+          scopes.stream().filter(expectedScopes::contains).collect(toUnmodifiableList());
+
+      return foundScopes.size() > 0;
     };
-
-    @SneakyThrows
-    private ReactiveJwtDecoder jwtDecoder() {
-        String publicKeyStr;
-
-        val publicKeyUrl = authProperties.getJwtPublicKeyUrl();
-        if (publicKeyUrl != null && !publicKeyUrl.isEmpty()) {
-            publicKeyStr = fetchJWTPublicKey(publicKeyUrl);
-        } else {
-            publicKeyStr = authProperties.getJwtPublicKeyStr();
-        }
-
-        val publicKeyContent = publicKeyStr
-                                       .replaceAll("\\n", "")
-                                       .replace("-----BEGIN PUBLIC KEY-----", "")
-                                       .replace("-----END PUBLIC KEY-----", "");
-
-        KeyFactory kf = KeyFactory.getInstance("RSA");
-        X509EncodedKeySpec keySpecX509 = new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyContent));
-        RSAPublicKey publicKey = (RSAPublicKey) kf.generatePublic(keySpecX509);
-
-        return NimbusReactiveJwtDecoder.withPublicKey(publicKey).build();
-
-    }
-
-    @SneakyThrows
-    private String fetchJWTPublicKey(String publicKeyUrl) {
-        log.info("Fetching EGO public key");
-        val publicKeyResource = resourceLoader.getResource(publicKeyUrl);
-
-        val stringBuilder = new StringBuilder();
-        val reader = new BufferedReader(
-                new InputStreamReader(publicKeyResource.getInputStream()));
-
-        reader.lines().forEach(stringBuilder::append);
-        return stringBuilder.toString();
-    }
-
-    @Bean
-    public Function<Authentication, Boolean> queryAndMutationScopeChecker() {
-        val expectedScopes = authProperties.getGraphqlScopes().getQueryAndMutation();
-        return authentication -> {
-            val scopes = authentication.getAuthorities().stream()
-                                 .map(Objects::toString)
-                                 .collect(toUnmodifiableList());
-
-            val foundScopes = scopes.stream()
-                                      .filter(expectedScopes::contains)
-                                      .collect(toUnmodifiableList());
-
-            return foundScopes.size() > 0;
-        };
-    }
+  }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/controller/impl/RunsApiController.java
+++ b/src/main/java/org/icgc/argo/workflow_management/controller/impl/RunsApiController.java
@@ -34,9 +34,13 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/runs")
 public class RunsApiController implements RunsApi {
 
+  /** Dependencies */
+  private final WorkflowExecutionService nextflowService;
+
   @Autowired
-  @Qualifier("nextflow")
-  private WorkflowExecutionService nextflowService;
+  public RunsApiController(@Qualifier("nextflow") WorkflowExecutionService nextflowService) {
+    this.nextflowService = nextflowService;
+  }
 
   @PostMapping
   public Mono<RunsResponse> postRun(@Valid @RequestBody RunsRequest runsRequest) {

--- a/src/main/java/org/icgc/argo/workflow_management/controller/model/RunsRequest.java
+++ b/src/main/java/org/icgc/argo/workflow_management/controller/model/RunsRequest.java
@@ -21,13 +21,12 @@ package org.icgc.argo.workflow_management.controller.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
+import java.util.HashMap;
+import java.util.Map;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotBlank;
-import java.util.HashMap;
-import java.util.Map;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/org/icgc/argo/workflow_management/controller/model/WorkflowEngineParams.java
+++ b/src/main/java/org/icgc/argo/workflow_management/controller/model/WorkflowEngineParams.java
@@ -21,11 +21,10 @@ package org.icgc.argo.workflow_management.controller.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.UUID;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/org/icgc/argo/workflow_management/secret/SecretProvider.java
+++ b/src/main/java/org/icgc/argo/workflow_management/secret/SecretProvider.java
@@ -16,36 +16,32 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.icgc.argo.workflow_management.config.security;
+package org.icgc.argo.workflow_management.secret;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
-import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.context.annotation.Configuration;
+import java.util.Optional;
 
-@Data
-@Configuration
-@ConfigurationProperties(prefix = "auth")
-public class AuthProperties {
+public abstract class SecretProvider {
 
-  String jwtPublicKeyUrl;
+  /**
+   * Return a secret with default scopes
+   *
+   * @return Secret String
+   */
+  public abstract Optional<String> generateSecret();
 
-  String jwtPublicKeyStr;
+  /**
+   * Return secret scoped to requested scopes
+   *
+   * @param scopes Scopes to generate secret with
+   * @return Secret String
+   */
+  public abstract Optional<String> generateSecretWithScopes(List<String> scopes);
 
-  GraphqlScopes graphqlScopes;
-
-  @Value
-  @ConstructorBinding
-  public static class GraphqlScopes {
-    ImmutableList<String> queryOnly;
-    ImmutableList<String> queryAndMutation;
-
-    public GraphqlScopes(List<String> queryOnly, List<String> queryAndMutation) {
-      this.queryOnly = ImmutableList.copyOf(queryOnly);
-      this.queryAndMutation = ImmutableList.copyOf(queryAndMutation);
-    }
-  }
+  /**
+   * Is this secret provider enabled?
+   *
+   * @return Enabled state
+   */
+  public abstract Boolean isEnabled();
 }

--- a/src/main/java/org/icgc/argo/workflow_management/secret/impl/ApiKeyProvider.java
+++ b/src/main/java/org/icgc/argo/workflow_management/secret/impl/ApiKeyProvider.java
@@ -16,36 +16,44 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.icgc.argo.workflow_management.config.security;
+package org.icgc.argo.workflow_management.secret.impl;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
-import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.context.annotation.Configuration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
 
-@Data
-@Configuration
-@ConfigurationProperties(prefix = "auth")
-public class AuthProperties {
+@Slf4j
+@RequiredArgsConstructor
+public class ApiKeyProvider extends SecretProvider {
 
-  String jwtPublicKeyUrl;
+  /** Dependencies */
+  private final Boolean enabled;
 
-  String jwtPublicKeyStr;
+  private final String apiKey;
 
-  GraphqlScopes graphqlScopes;
+  @Override
+  public Optional<String> generateSecret() {
+    log.debug("ApiKeyProvider returning secret.");
+    return enabled ? Optional.of(apiKey) : Optional.empty();
+  }
 
-  @Value
-  @ConstructorBinding
-  public static class GraphqlScopes {
-    ImmutableList<String> queryOnly;
-    ImmutableList<String> queryAndMutation;
+  /**
+   * API Keys do not have the ability to have their scopes modified as they are already issued at
+   * call time.
+   *
+   * @return API Key
+   */
+  @Override
+  public Optional<String> generateSecretWithScopes(List<String> scopes) {
+    log.debug("ApiKeyProvider returning secret.");
+    log.warn("Trying to generate API key that is scoped. API Keys cannot be dynamically scoped!");
+    return generateSecret();
+  }
 
-    public GraphqlScopes(List<String> queryOnly, List<String> queryAndMutation) {
-      this.queryOnly = ImmutableList.copyOf(queryOnly);
-      this.queryAndMutation = ImmutableList.copyOf(queryAndMutation);
-    }
+  @Override
+  public Boolean isEnabled() {
+    return enabled;
   }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/secret/impl/NoSecretProvider.java
+++ b/src/main/java/org/icgc/argo/workflow_management/secret/impl/NoSecretProvider.java
@@ -16,36 +16,30 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.icgc.argo.workflow_management.config.security;
+package org.icgc.argo.workflow_management.secret.impl;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
-import lombok.Data;
-import lombok.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
-import org.springframework.context.annotation.Configuration;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
 
-@Data
-@Configuration
-@ConfigurationProperties(prefix = "auth")
-public class AuthProperties {
+@Slf4j
+public class NoSecretProvider extends SecretProvider {
 
-  String jwtPublicKeyUrl;
+  @Override
+  public Optional<String> generateSecret() {
+    log.debug("NoSecretProvider returning empty optional.");
+    return Optional.empty();
+  }
 
-  String jwtPublicKeyStr;
+  @Override
+  public Optional<String> generateSecretWithScopes(List<String> scopes) {
+    log.debug("NoSecretProvider returning empty optional.");
+    return Optional.empty();
+  }
 
-  GraphqlScopes graphqlScopes;
-
-  @Value
-  @ConstructorBinding
-  public static class GraphqlScopes {
-    ImmutableList<String> queryOnly;
-    ImmutableList<String> queryAndMutation;
-
-    public GraphqlScopes(List<String> queryOnly, List<String> queryAndMutation) {
-      this.queryOnly = ImmutableList.copyOf(queryOnly);
-      this.queryAndMutation = ImmutableList.copyOf(queryAndMutation);
-    }
+  @Override
+  public Boolean isEnabled() {
+    return false;
   }
 }

--- a/src/main/java/org/icgc/argo/workflow_management/secret/impl/OAuth2BearerTokenProvider.java
+++ b/src/main/java/org/icgc/argo/workflow_management/secret/impl/OAuth2BearerTokenProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.icgc.argo.workflow_management.secret.impl;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OAuth2BearerTokenProvider extends SecretProvider {
+
+  /** Dependencies */
+  private final Boolean enabled;
+
+  private final String clientId;
+  private final String clientSecret;
+  private final String tokenUri;
+
+  @Override
+  public Optional<String> generateSecret() {
+    log.debug("OAuth2BearerTokenProvider generating secret with default scopes");
+    return enabled ? Optional.of(getRestTemplate().getAccessToken().getValue()) : Optional.empty();
+  }
+
+  @Override
+  public Optional<String> generateSecretWithScopes(@NonNull List<String> scopes) {
+    log.debug("OAuth2BearerTokenProvider generating secret with scopes: {}", scopes);
+    return enabled
+        ? Optional.of(getRestTemplate(scopes).getAccessToken().getValue())
+        : Optional.empty();
+  }
+
+  @Override
+  public Boolean isEnabled() {
+    return enabled;
+  }
+
+  private OAuth2RestTemplate getRestTemplate() {
+    return getRestTemplate(List.of());
+  }
+
+  private OAuth2RestTemplate getRestTemplate(@NonNull List<String> scopes) {
+    log.debug(
+        "Requesting new Bearer Token with client credentials grant using clientId: {}", clientId);
+    val clientCredentialDetails = new ClientCredentialsResourceDetails();
+    clientCredentialDetails.setClientId(clientId);
+    clientCredentialDetails.setClientSecret(clientSecret);
+    clientCredentialDetails.setAccessTokenUri(tokenUri);
+    if (!scopes.isEmpty()) {
+      clientCredentialDetails.setScope(scopes);
+    }
+    return new OAuth2RestTemplate(clientCredentialDetails);
+  }
+}

--- a/src/main/java/org/icgc/argo/workflow_management/service/WorkflowExecutionService.java
+++ b/src/main/java/org/icgc/argo/workflow_management/service/WorkflowExecutionService.java
@@ -18,13 +18,12 @@
 
 package org.icgc.argo.workflow_management.service;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import org.icgc.argo.workflow_management.controller.model.RunsResponse;
 import org.icgc.argo.workflow_management.service.model.WESRunParams;
 import org.springframework.security.access.prepost.PreAuthorize;
 import reactor.core.publisher.Mono;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 
 public interface WorkflowExecutionService {
   @HasQueryAndMutationAccess
@@ -35,6 +34,5 @@ public interface WorkflowExecutionService {
 
   @Retention(RetentionPolicy.RUNTIME)
   @PreAuthorize("@queryAndMutationScopeChecker.apply(authentication)")
-  @interface HasQueryAndMutationAccess {
-  }
+  @interface HasQueryAndMutationAccess {}
 }

--- a/src/main/java/org/icgc/argo/workflow_management/util/Reflections.java
+++ b/src/main/java/org/icgc/argo/workflow_management/util/Reflections.java
@@ -86,7 +86,8 @@ public class Reflections {
         }
       } catch (IllegalAccessException | InvocationTargetException e) {
         log.error("invokeDeclaredMethod exception", e);
-        throw new ReflectionUtilsException(String.format("Invoke error for method: %s", methodName));
+        throw new ReflectionUtilsException(
+            String.format("Invoke error for method: %s", methodName));
       }
     } else {
       throw new ReflectionUtilsException(String.format("Cannot access method: %s", methodName));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,13 +4,16 @@ nextflow:
     namespace: "default"
     serviceAccount: "default"
     volMounts:
-      - "pv-claim:/some/dir"
+      - "task-pv-claim:/mnt/data"
     masterUrl: "localhost:8080"
     trustCertificate: false
   weblogUrl: "http://localhost"
   monitor:
     sleepInterval: 1000 # milliseconds
     maxErrorLogLines: 50 # we put the last ${maxErrorLogLines} into the error message if a Pod fails
+
+secret:
+  enabled: false
 
 ---
 spring.profiles: secure
@@ -22,3 +25,19 @@ auth:
       - RDPC-CA.READ
     queryAndMutation:
       - RDPC-CA.WRITE
+
+---
+spring.profiles: apiKey
+
+secret:
+  enabled: true
+  apiKey: testapikeytotallylegit
+
+---
+spring.profile: oauth2Token
+
+secret:
+  enabled: true
+  clientId: testId
+  clientSecret: testSecret
+  tokenUri: http://localhost:8080/oauth/token

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ nextflow:
     namespace: "default"
     serviceAccount: "default"
     volMounts:
-      - "task-pv-claim:/mnt/data"
+      - "pv-claim:/some/dir"
     masterUrl: "localhost:8080"
     trustCertificate: false
   weblogUrl: "http://localhost"

--- a/src/test/java/org/icgc/argo/workflow_management/ErrorHandlingTests.java
+++ b/src/test/java/org/icgc/argo/workflow_management/ErrorHandlingTests.java
@@ -49,6 +49,7 @@ import nextflow.exception.AbortRunException;
 import nextflow.exception.DuplicateProcessInvocation;
 import nextflow.exception.IllegalFileException;
 import nextflow.exception.MissingFileException;
+import org.icgc.argo.workflow_management.config.secret.NoSecretProviderConfig;
 import org.icgc.argo.workflow_management.config.security.AuthDisabledConfig;
 import org.icgc.argo.workflow_management.controller.impl.RunsApiController;
 import org.icgc.argo.workflow_management.controller.model.RunsRequest;
@@ -76,7 +77,14 @@ import org.springframework.web.server.ResponseStatusException;
 // TODO: rtisma    create test for
 // https://github.com/${owner}/${repo}/blob/${branch}/${path-to-file}
 @Slf4j
-@Import(value = {NextflowService.class, NextflowProperties.class, GlobalExceptionHandler.class, AuthDisabledConfig.class})
+@Import(
+    value = {
+      NoSecretProviderConfig.class,
+      NextflowService.class,
+      NextflowProperties.class,
+      GlobalExceptionHandler.class,
+      AuthDisabledConfig.class
+    })
 @RunWith(SpringRunner.class)
 @ExtendWith(SpringExtension.class)
 @WebFluxTest(controllers = RunsApiController.class)

--- a/src/test/java/org/icgc/argo/workflow_management/util/WorkflowTest.java
+++ b/src/test/java/org/icgc/argo/workflow_management/util/WorkflowTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.Map;
 import lombok.val;
 import org.icgc.argo.workflow_management.controller.model.WorkflowEngineParams;
+import org.icgc.argo.workflow_management.secret.SecretProvider;
+import org.icgc.argo.workflow_management.secret.impl.NoSecretProvider;
 import org.icgc.argo.workflow_management.service.NextflowService;
 import org.icgc.argo.workflow_management.service.model.WESRunParams;
 import org.icgc.argo.workflow_management.service.properties.NextflowProperties;
@@ -41,7 +43,8 @@ public class WorkflowTest {
 
   static void runTest(WESRunParams params) {
     NextflowProperties config = new NextflowProperties();
-    val service = new NextflowService(config);
+    SecretProvider secretProvider = new NoSecretProvider();
+    val service = new NextflowService(config, secretProvider);
     val result = service.run(params);
     System.err.println(result.toString());
   }


### PR DESCRIPTION
# Kubernetes Secret Creation

New Abstract SecretProvider calls that provides the following contract:
```java
  public abstract Optional<String> generateSecret();
  public abstract Optional<String> generateSecretWithScopes(List<String> scopes);
  public abstract Boolean isEnabled();
```

Will always return an optional whether or not secrets have been disabled. This eliminates the need to null checking, and conditional branching dependant on secret presence or run profile switch. 

Kubernetes secret Name is currently: `$runName-secret`
Field within kubernetes secret that contains secret: `secret`

```java
secretProvider.generateSecret().ifPresentOrElse(
  secret -> // Do your stuff here
  () -> // Handle your disabled/failure logic here
)
```

## Run Profiles

### default
No-Op secret provider that always returns empty optional.

### apiKey
Returns configured API Key.

```yaml
secret:
  enabled: true
  apiKey: testapikeytotallylegit

```

### oauth2Token
Uses client credentials grant type to communicate to authorization provider and retrieve an access token to be used as a bearer token. In our case a base64 encoded JWT. 

```yaml
secret:
  enabled: true
  clientId: testId
  clientSecret: testSecret
  tokenUri: http://localhost:8080/oauth/token
```