### PR TITLE
Update java version to avoid Bugs with K8s >1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN ./mvnw clean package -DskipTests
 #############################
 #   Server
 #############################
-FROM adoptopenjdk/openjdk11:jre-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.8_10-alpine
 
 ENV APP_HOME /srv
 ENV APP_USER wfuser


### PR DESCRIPTION
The allready used java version (jre-11.0.6_10) is not capable to validate SSL certificates if Kubernetes >=1.17 is used. Therefore, it is impossible to run Nextflow ([see Nextflow issue](https://github.com/nextflow-io/nextflow/issues/1462)). Java version jre-11.0.8_10 fixes that issue.