### PR TITLE
move weblogging into wes consumer only and fmt

### DIFF
--- a/src/main/java/org/icgc/argo/workflow_management/streams/WebLogEventSender.java
+++ b/src/main/java/org/icgc/argo/workflow_management/streams/WebLogEventSender.java
@@ -110,8 +110,8 @@ public class WebLogEventSender {
             res -> {
               // Don't want to proceed with stream if response from weblog is bad, so throw error
               if (!res.getStatusCode().is2xxSuccessful() || !Objects.equals(res.getBody(), true)) {
-                log.debug("Event failed to send to or process in weblog!");
-                return Mono.error(new Exception("Event failed to send to or process in weblog!"));
+                log.info("*** Failed to send event to weblog! ***");
+                return Mono.error(new Exception("Failed to send event to weblog!"));
               }
               log.debug("Message sent to weblog: " + jsonReadyObject);
               return Mono.just(res.getBody());

--- a/src/main/java/org/icgc/argo/workflow_management/streams/utils/RabbitmqUtils.java
+++ b/src/main/java/org/icgc/argo/workflow_management/streams/utils/RabbitmqUtils.java
@@ -34,10 +34,7 @@ public class RabbitmqUtils {
       RabbitEndpointService rabbit, String topicName) {
     return rabbit
         .declareTopology(
-            topologyBuilder ->
-                topologyBuilder
-                    .declareExchange(topicName)
-                    .type(ExchangeType.topic))
+            topologyBuilder -> topologyBuilder.declareExchange(topicName).type(ExchangeType.topic))
         .createTransactionalProducerStream(WfMgmtRunMsg.class)
         .route()
         .toExchange(topicName)

--- a/src/main/java/org/icgc/argo/workflow_management/wes/NextflowService.java
+++ b/src/main/java/org/icgc/argo/workflow_management/wes/NextflowService.java
@@ -86,22 +86,18 @@ public class NextflowService implements WorkflowExecutionService {
 
   public Mono<RunsResponse> run(RunParams params) {
     log.debug("Initializing run: {}", params);
-    return webLogSender
-        .sendWfMgmtEvent(params, WesState.INITIALIZING)
-        .map(r -> this.startRun(params))
+    return Mono.just(params)
+        .map(this::startRun)
         .map(RunsResponse::new)
-        .doOnError(t -> webLogSender.sendWfMgmtEventAsync(params, WesState.SYSTEM_ERROR))
         .onErrorMap(toRuntimeException("startRun", params.getRunId()))
         .subscribeOn(scheduler);
   }
 
   public Mono<RunsResponse> cancel(@NonNull String runId) {
     log.debug("Cancelling run: {}", runId);
-    return webLogSender
-        .sendWfMgmtEvent(runId, WesState.CANCELING)
-        .map(r -> this.cancelRun(runId))
+    return Mono.just(runId)
+        .map(this::cancelRun)
         .map(RunsResponse::new)
-        .doOnError(t -> webLogSender.sendWfMgmtEventAsync(runId, WesState.SYSTEM_ERROR))
         .onErrorMap(toRuntimeException("cancelRun", runId))
         .subscribeOn(scheduler);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,7 +86,7 @@ spring.cloud.stream:
       weblogConsumer-in-0:
         consumer:
           enableDlq: true
-          dlqName: weblog-in-0_dlq
+          dlqName: weblog-into-mgmt_dlq
           autoCommitOnError: true
           autoCommitOffset: true
 #          resetOffsets: true


### PR DESCRIPTION
changes:
- remove wesConsumer onErrorContinue, its supersceding the onErrorResume which is the one we want
- move weblogging to wesConsumer only, we're actually double logging SYSTEM_ERRORs onces from wesConsumer and once from nextflowService