### PR TITLE
upgrade springboot 2.6.6 and misc dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.4</version>
+        <version>2.6.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.icgc.argo</groupId>
@@ -34,6 +34,10 @@
     <properties>
         <java.version>11</java.version>
         <reactor-rabbitmq-streams.version>0.0.9</reactor-rabbitmq-streams.version>
+        <spring-cloud-stream-kafka.version>3.2.2</spring-cloud-stream-kafka.version>
+        <spring-security-oauth2-autoconfigure.version>2.6.6</spring-security-oauth2-autoconfigure.version>
+        <kubernetes-client.version>4.7.0</kubernetes-client.version>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -74,14 +78,20 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>4.7.0</version>
+            <version>${kubernetes-client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <!-- Spring-boot security dependencies -->
         <dependency>
             <groupId>org.springframework.security.oauth.boot</groupId>
             <artifactId>spring-security-oauth2-autoconfigure</artifactId>
-            <version>2.5.2</version>
+            <version>${spring-security-oauth2-autoconfigure.version}</version>
         </dependency>
 
         <!-- Graphql -->
@@ -132,7 +142,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-stream-kafka</artifactId>
-            <version>3.1.3</version>
+            <version>${spring-cloud-stream-kafka.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,14 +24,14 @@ logging.level:
   org.icgc.argo: debug
 
 ---
-spring.profiles: apiKey
+spring.config.activate.on-profile: apiKey
 
 secret:
   enabled: true
   apiKey: testapikeytotallylegit
 
 ---
-spring.profiles: oauth2Token
+spring.config.activate.on-profile: oauth2Token
 
 secret:
   enabled: true
@@ -55,7 +55,7 @@ wes.consumer:
     topicRoutingKeys: "INITIALIZING, CANCELING" # comma separated Array of keys
 
 ---
-spring.profiles: gatekeeper
+spring.config.activate.on-profile: gatekeeper
 
 gatekeeper.consumer:
     queue: "gatekeeper-in-queue"
@@ -92,7 +92,7 @@ spring.jpa:
     ddl-auto: update
 
 ---
-spring.profiles: test
+spring.config.activate.on-profile: test
 
 spring.jpa:
   hibernate:


### PR DESCRIPTION
changes:
- spring updates to boot, cloud and security-oauth2 (client used to generate app jwts for wfs)
- kubernetes client update
- app yaml profiles to config.activate.on-profile
- jackson core explicitly defined to resolve mistmatch between Jackson functions and versions used by dependencies